### PR TITLE
fix(remote): import SSEServerTransport in remote/start.ts

### DIFF
--- a/src/remote/start.ts
+++ b/src/remote/start.ts
@@ -7,6 +7,7 @@
  */
 
 import { structuredLog } from '../lib/logger.js';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { apiCircuitBreaker, runWithApiKey } from '../lib/api-client.js';
 import {
   handleSaveConversation,


### PR DESCRIPTION
## Problem

The legacy `/sse` and `/messages` endpoints in `src/remote/start.ts` reference `SSEServerTransport` (line 735) without importing it. When any client (e.g. older Claude Desktop / Cursor versions) hits these endpoints, Node crashes with:

```
ReferenceError: SSEServerTransport is not defined
    at file:///opt/services/purmemo-mcp/current/dist/remote/start.js:691:27
```

systemd's auto-restart hides the symptom on the polymathematics OCI host, but the process crashes again on the next SSE connection.

## Root cause

The import exists in `src/server.ts:43` but was never duplicated in `src/remote/start.ts`. The dynamic-import pattern elsewhere in the file works fine for modules used lazily, but `SSEServerTransport` is referenced synchronously in a route handler, so it must be imported at module top.

## Fix

Add the standard import next to `structuredLog`:

```ts
import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
```

Verified: `npm run build` passes clean.

## Discovered while

Migrating purmemo-mcp from Render to an OCI Always-Free VM ("polymathematics") on 2026-05-20. systemd journal showed exactly one restart shortly after deploy, traced to this crash path.