### PR TITLE
fix(incident-reporter): strip trailing slash from API base (MCP reports were 404ing)

### DIFF
--- a/src/lib/incident-reporter.ts
+++ b/src/lib/incident-reporter.ts
@@ -15,7 +15,10 @@
  * payloads, never user content, never raw stacks.
  */
 
-const API_BASE = process.env.PURMEMO_API_URL || 'https://api.purmemo.ai';
+// Strip any trailing slash: PURMEMO_API_URL is set with a trailing "/" in the
+// box env, which produced a double-slash URL (api.purmemo.ai//api/v1/...) that
+// the API 404s — silently dropping every MCP incident report (found 2026-06-13).
+const API_BASE = (process.env.PURMEMO_API_URL || 'https://api.purmemo.ai').replace(/\/+$/, '');
 
 let warnedMissing = false;
 


### PR DESCRIPTION
Box env PURMEMO_API_URL has a trailing slash → reporter built a double-slash URL the API 404s → every MCP report silently dropped (zero mcp rows ever, despite wiring+token present). Proven: double-slash 404, single-slash 401. Fix strips trailing slashes. After box redeploy, real MCP tool errors land in the hub. 🤖 Generated with [Claude Code](https://claude.com/claude-code)