### PR TITLE
fix(remote): stop reaping idle-but-connected MCP sessions

### DIFF
--- a/src/remote/start.ts
+++ b/src/remote/start.ts
@@ -176,14 +176,24 @@ export async function startRemoteServer(ctx) {
   const mcpSessions = new Map();
   const SUPPORTED_PROTOCOL_VERSIONS = new Set(['2024-11-05', '2025-11-05', '2025-03-26']);
 
-  // Session cleanup — remove stale sessions every 5 minutes (matches Python)
+  // Session cleanup — remove stale sessions every 5 minutes (matches Python).
+  // A session is reaped only if it is BOTH past maxAge AND has no live SSE
+  // connection. This decouples socket liveness from the activity-based reaper:
+  // a client that holds an open SSE stream is never considered stale, even if
+  // it makes no tool calls. (Fixes the twice-a-day idle-disconnect: the 30s SSE
+  // heartbeat keeps the socket warm but previously never refreshed lastActivity,
+  // so an idle-but-connected client was reaped after 30 min.) maxAge raised from
+  // 30 min to 2 h to match plausible interactive usage; the sseOpen guard is the
+  // real protection.
   const sessionCleanupInterval = setInterval(() => {
-    const maxAge = 30 * 60 * 1000; // 30 minutes
+    const maxAge = 2 * 60 * 60 * 1000; // 2 hours
     const now = Date.now();
     let cleaned = 0;
     for (const [sid, sess] of mcpSessions) {
+      if (sess.sseOpen) continue; // never reap a session with a live SSE stream
       if (now - sess.lastActivity > maxAge) {
         mcpSessions.delete(sid);
+        connMonitor.trackDisconnection(sid); // keep monitor count accurate on reap
         cleaned++;
       }
     }
@@ -490,6 +500,12 @@ export async function startRemoteServer(ctx) {
 
       // ── ping ──
       if (method === 'ping') {
+        // Refresh activity so a client that only pings (no tool calls) isn't
+        // reaped. ping is intentionally unauthenticated, so look up the session
+        // best-effort without requiring auth.
+        const pingSid = req.headers['mcp-session-id'] || req.headers['Mcp-Session-Id'];
+        const pingSess = pingSid && mcpSessions.get(pingSid);
+        if (pingSess) pingSess.lastActivity = Date.now();
         return sendJSON(res, { jsonrpc: '2.0', id: requestId, result: {} });
       }
 
@@ -707,6 +723,9 @@ export async function startRemoteServer(ctx) {
     if (!mcpSessions.has(sessionId)) {
       mcpSessions.set(sessionId, { token: apiKey, createdAt: Date.now(), lastActivity: Date.now() });
     }
+    // Mark the session as holding a live SSE stream so the reaper never evicts
+    // it while connected (see sessionCleanupInterval above).
+    mcpSessions.get(sessionId).sseOpen = true;
 
     res.writeHead(200, {
       'Content-Type': 'text/event-stream',
@@ -718,11 +737,17 @@ export async function startRemoteServer(ctx) {
 
     const heartbeat = setInterval(() => {
       if (res.writableEnded) { clearInterval(heartbeat); return; }
+      // Refresh activity on every heartbeat: a connected-but-idle client should
+      // never be reaped. This is the core idle-disconnect fix.
+      const sess = mcpSessions.get(sessionId);
+      if (sess) sess.lastActivity = Date.now();
       res.write(`data: ${JSON.stringify({ jsonrpc: '2.0', method: 'notifications/keepalive', params: { timestamp: new Date().toISOString() } })}\n\n`);
     }, 30000);
 
     req.on('close', () => {
       clearInterval(heartbeat);
+      const sess = mcpSessions.get(sessionId);
+      if (sess) sess.sseOpen = false; // socket gone — eligible for normal reaping again
       connMonitor.trackDisconnection(sessionId);
     });
   });


### PR DESCRIPTION
## Problem
The remote MCP server (mcp.purmemo.ai) forces a reconnect after ~30 min of no tool calls, even while the client holds a healthy SSE connection. Reported symptom: "had to connect it twice today, which is weird because whenever it's connected it just stays connected."

## Root cause (verified line-by-line, not inferred)
The server is **not** crashing — uptime ~71h, no restarts since June 13. The disconnect is a stale-session bug in the custom Streamable-HTTP handler:

- A 5-min cleanup reaper evicts any session whose `lastActivity` is older than `maxAge` (was **30 min**).
- `lastActivity` was refreshed **only** by substantive `POST /mcp/messages` tool calls.
- The 30s SSE heartbeat kept the TCP socket warm but **never touched `lastActivity`** → an idle-but-connected client was reaped at 30 min. The socket stayed open; the session behind it was deleted. The next tool call carried a session id the server had thrown away → forced reconnect.
- MCP-protocol `ping` also early-returned **before** the `lastActivity` write, so pinging clients couldn't stay alive either.
- `ConnectionMonitor.active_connections` never decremented on reap (`trackDisconnection` only fired on socket `close`), inflating the count. Live metrics showed **70 "active"** connections including one open ~70h with **0 tool calls** — a ghost entry from a reaped session.

## Fix
1. **SSE heartbeat refreshes `lastActivity`** (core fix) — a connected-but-idle client is never stale.
2. **`ping` refreshes `lastActivity`** (best-effort, unauthenticated as before).
3. **Reaper skips any session with a live SSE stream** via an `sseOpen` flag — decouples socket liveness from activity-based reaping.
4. **Reaper calls `trackDisconnection`** so the monitor count stays accurate; `maxAge` raised 30 min → 2 h to match interactive usage (the `sseOpen` guard is the real protection).

## Scope / risk
- One file: `src/remote/start.ts`, +27 / −2.
- No schema, infra, or auth-contract changes. Session semantics unchanged except the bug.
- `tsc` build passes clean.

## Not in scope (follow-up ADR)
The custom handler exists for ChatGPT-widget compatibility (it intentionally does **not** use the SDK `StreamableHTTPServerTransport`). Adopting the SDK transport is a separate architectural decision and not required to stop the disconnects.

## Verification after merge/deploy
Watch `GET /mcp/metrics`: active_connections should stop monotonically climbing and should decrement as idle sessions age out past 2h; `disconnects` should become non-zero on reap. No client should be forced to reconnect after an idle gap < 2h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)