### PR TITLE
fix(ci): route poly auto-deploy through bespoke purmemo-mcp-deploy.sh

### DIFF
--- a/.github/workflows/deploy-polymathematics.yml
+++ b/.github/workflows/deploy-polymathematics.yml
@@ -23,4 +23,9 @@ jobs:
           echo "$POLY_SSH_KEY" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
           ssh-keyscan -H "$POLY_HOST" >> ~/.ssh/known_hosts 2>/dev/null
-          ssh -i ~/.ssh/id_ed25519 "$POLY_USER@$POLY_HOST" "/usr/local/bin/poly-deploy.sh purmemo-mcp"
+          # Route through the poly wrapper so the bespoke purmemo-mcp-deploy.sh
+          # is used (run via sudo). The generic poly-deploy.sh ran git AS ubuntu
+          # inside the root-owned releases/ tree, hit "dubious ownership", and
+          # silently failed every push (see 2026-06-16 fix). The bespoke script
+          # mirrors kiru's proven _git pattern and posts ✅/🔴 to Slack itself.
+          ssh -i ~/.ssh/id_ed25519 "$POLY_USER@$POLY_HOST" "poly deploy purmemo/mcp"


### PR DESCRIPTION
## Problem
Auto-deploy to polymathematics has **silently failed on every push for days**. The "Deploy to polymathematics" workflow failed in ~10–14s on the last three pushes (June 13 ×2, June 16 merge of #13) with identical errors. The green **Tests** check next to it masked the red **Deploy** check, so it looked healthy.

Root cause: the workflow called the **generic** `poly-deploy.sh`, which runs its `git fetch`/checkout **as `ubuntu` directly inside the root-owned `releases/` tree**. Git refuses to operate on a repo owned by another user (`fatal: detected dubious ownership`) and the script exits 128 before fetching any code. That's why the June 13 build sat un-updated until it was force-deployed by hand with sudo.

## Fix — mirror kiru's proven working pattern
Kiru deploys fine because it keeps a **dedicated ubuntu-owned `_git` checkout**, runs git as `sudo -u ubuntu` there, and the script itself runs as root (so `systemctl restart` works). This change gives purmemo the same:

**Box-side (already installed + live-tested):** new `/usr/local/bin/purmemo-mcp-deploy.sh` that:
- Keeps an ubuntu-owned `_git` checkout (bootstrapped on first run).
- Materializes each release via `git archive` → ownership-clean, no `.git` traps.
- `npm install && npm run build`, verifies `dist/server.js`, atomic symlink swap, restart `purmemo-mcp.service`.
- Polls `/health` for 20s; **auto-rolls-back** to the previous release on failure.
- Posts **✅ / 🔴 to the #polymathematic-oci-server Slack channel on success AND failure** — a broken deploy can never again masquerade as success.

**This PR (CI):** the workflow now calls `poly deploy purmemo/mcp` instead of `poly-deploy.sh purmemo-mcp`. The poly wrapper auto-routes purmemo/mcp to the bespoke script (run via sudo), exactly like kiru.

## Verification (already done, live)
- Ran the new deployer end-to-end on the box: bootstrap → build → promote → health **green** → Slack ✅ posted.
- `_git` checkout confirmed ubuntu-owned; current release is the latest SHA.
- Slack posting to the ops channel confirmed working.
- The MCP idle-disconnect fix (#13) is already live via this same script.

## Risk
- One-line CI change + a box-side script that already passed a live run. Auto-rollback + health gate bound the blast radius. Secrets remain GitHub repo secrets (no inline values). Fully reversible.

## After merge
The next push to `main` will exercise this path automatically. Watch for the ✅ line in #polymathematic-oci-server; a 🔴 there now means a real deploy failure instead of a silent one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)