### PR TITLE
ci(deploy): Slack alert on CI-level deploy failure + (branch protection set)

### DIFF
--- a/.github/workflows/deploy-polymathematics.yml
+++ b/.github/workflows/deploy-polymathematics.yml
@@ -29,3 +29,19 @@ jobs:
           # silently failed every push (see 2026-06-16 fix). The bespoke script
           # mirrors kiru's proven _git pattern and posts ✅/🔴 to Slack itself.
           ssh -i ~/.ssh/id_ed25519 "$POLY_USER@$POLY_HOST" "poly deploy purmemo/mcp"
+
+      # Failure surfacing: the box script posts 🔴 on a deploy/health failure,
+      # but if SSH or the workflow itself fails BEFORE the script runs, nothing
+      # posts. This step fires only on failure and makes a best-effort Slack
+      # alert via the box's own helper, so a CI/SSH-level failure can't hide.
+      # If the box is fully unreachable this also fails — and GitHub's native
+      # failed-workflow notification on main is the backstop for that case.
+      - name: Alert on deploy failure
+        if: failure()
+        continue-on-error: true
+        env:
+          POLY_HOST: ${{ secrets.POLY_HOST }}
+          POLY_USER: ${{ secrets.POLY_USER }}
+        run: |
+          ssh -o ConnectTimeout=10 -i ~/.ssh/id_ed25519 "$POLY_USER@$POLY_HOST" \
+            "/usr/local/bin/poly-slack.sh '🔴 [purmemo-mcp] CI deploy job FAILED before/at the deploy step (run ${{ github.run_id }}, sha ${{ github.sha }}). Check the GitHub Actions log — the box deploy script may not have run.'" || true


### PR DESCRIPTION
## What this does
Closes the last gap from the cross-model pressure-test of the deploy fixes: a **failed required check sat next to a green one for days and nothing blocked or escalated it.**

Two parts:

### 1. Branch protection on `main` (already applied via API, 2026-06-16)
- **`test` is now a REQUIRED status check** (strict / branch-must-be-up-to-date) before any PR can merge.
- Force-pushes and branch deletion disabled on `main`.
- `enforce_admins=false` so you're never locked out of an emergency merge.
- Note: the **`deploy`** check runs *post-merge* (on push to main), so by design it cannot be a pre-merge gate. The durable catch for deploy failures is the required `test` gate + the Slack alert below + GitHub's native failed-workflow notification.

### 2. CI-level deploy-failure alert (this PR)
The box-side script already posts ✅/🔴 to Slack — but only once it runs. If **SSH or the CI job fails before the script runs**, nothing posted (the original silent failure). This adds an `if: failure()` step that best-effort posts a 🔴 to the ops channel via the box's own `poly-slack.sh`. If the box is fully unreachable, that step also fails — and GitHub's native failed-run notification on `main` is the backstop.

## Why not make `deploy` a required check?
Because it's a post-merge push-triggered job, not a PR check — requiring it would gate nothing real. This was verified against the workflow triggers, not assumed.

## Risk
Additive only: one failure-path CI step (`continue-on-error: true`, can't break a green deploy) + branch protection that still lets admins merge. Fully reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)